### PR TITLE
NULL-169-be-memo-findAll-update-delete-swagger

### DIFF
--- a/src/main/java/com/example/memo/memo/MemoApi.java
+++ b/src/main/java/com/example/memo/memo/MemoApi.java
@@ -55,6 +55,7 @@ public interface MemoApi {
         value = {
             @ApiResponse(responseCode = "200"),
             @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(hidden = true))),
         }
     )

--- a/src/main/java/com/example/memo/memo/models/MemoResponse.java
+++ b/src/main/java/com/example/memo/memo/models/MemoResponse.java
@@ -3,6 +3,7 @@ package com.example.memo.memo.models;
 import java.util.List;
 
 import com.example.memo.memo.service.models.Memo;
+import com.example.memo.memo.service.models.Tag;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -14,16 +15,31 @@ public record MemoResponse(
     String content,
 
     @Schema(description = "태그", example = """
-        ["일정", "멘토링"]
+        [
+            {"id": "60c72b3e9b1e8b1e4c8b4568", "name": "일정"},
+            {"id": "60c72b4f9b1e8b1e4c8b4569", "name": "멘토링"}
+        ]
         """)
-    List<String> tags
+    List<InnerTag> tags
 ) {
 
-    public static MemoResponse from(Memo memo) {
+    public record InnerTag(
+        @Schema(description = "태그 ID", example = "60c72b3e9b1e8b1e4c8b4568")
+        String id,
+
+        @Schema(description = "태그 이름", example = "일정")
+        String name
+    ) {
+
+    }
+
+    public static MemoResponse from(Memo memo, List<Tag> tags) {
         return new MemoResponse(
             memo.getId(),
             memo.getContent(),
-            memo.getTags()
+            tags.stream()
+                .map(tag -> new MemoResponse.InnerTag(tag.getId(), tag.getName()))
+                .toList()
         );
     }
 }

--- a/src/main/java/com/example/memo/memo/models/UpdateMemoRequest.java
+++ b/src/main/java/com/example/memo/memo/models/UpdateMemoRequest.java
@@ -12,14 +12,9 @@ import jakarta.validation.constraints.NotBlank;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record UpdateMemoRequest(
-    @Schema(description = "내용", example = "내일은 5시에 멘토링을 들어야해", requiredMode = REQUIRED)
+    @Schema(description = "내용", example = "내일 5시로 멘토링이 변경되었다.", requiredMode = REQUIRED)
     @NotBlank(message = "내용은 비워둘 수 없습니다.")
-    String content,
-
-    @Schema(description = "태그 이름", example = """
-        ["일정", "멘토링"]
-        """, requiredMode = REQUIRED)
-    List<String> tagNames
+    String content
 ) {
 
 }

--- a/src/main/java/com/example/memo/memo/models/UpdateMemoResponse.java
+++ b/src/main/java/com/example/memo/memo/models/UpdateMemoResponse.java
@@ -5,6 +5,7 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseS
 import java.util.List;
 
 import com.example.memo.memo.service.models.Memo;
+import com.example.memo.memo.service.models.Tag;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -14,20 +15,35 @@ public record UpdateMemoResponse(
     @Schema(description = "메모 고유 ID", example = "61b72b3e9b1e8b1e4c8b4560")
     String id,
 
-    @Schema(description = "내용", example = "소마 근처 맛집 : 맥도날드")
+    @Schema(description = "내용", example = "내일 5시로 멘토링이 변경되었다.")
     String content,
 
     @Schema(description = "태그", example = """
-        ["장소", "맛집"]
+        [
+            {"id": "60c72b3e9b1e8b1e4c8b4568", "name": "일정"},
+            {"id": "60c72b4f9b1e8b1e4c8b4569", "name": "멘토링"}
+        ]
         """)
-    List<String> tags
+    List<InnerTag> tags
 ) {
 
-    public static UpdateMemoResponse from(Memo memo) {
+    public record InnerTag(
+        @Schema(description = "태그 ID", example = "60c72b3e9b1e8b1e4c8b4568")
+        String id,
+
+        @Schema(description = "태그 이름", example = "일정")
+        String name
+    ) {
+
+    }
+
+    public static UpdateMemoResponse from(Memo memo, List<Tag> tags) {
         return new UpdateMemoResponse(
             memo.getId(),
             memo.getContent(),
-            memo.getTags()
+            tags.stream()
+                .map(tag -> new UpdateMemoResponse.InnerTag(tag.getId(), tag.getName()))
+                .toList()
         );
     }
 }

--- a/src/main/java/com/example/memo/memo/service/MemoService.java
+++ b/src/main/java/com/example/memo/memo/service/MemoService.java
@@ -107,9 +107,6 @@ public class MemoService {
     }
 
     private List<Memo> searchMemoByIdList(List<String> ids) {
-        for (String id : ids) {
-            System.out.println(id);
-        }
         return ids.stream()
             .map(memoRepository::getById)
             .toList();

--- a/src/main/java/com/example/memo/memo/service/exception/MemoExceptionHandler.java
+++ b/src/main/java/com/example/memo/memo/service/exception/MemoExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.example.memo.memo.service.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class MemoExceptionHandler {
+
+    @ExceptionHandler(MemoNotFoundException.class)
+    public ResponseEntity<String> handleMemoNotFoundException(MemoNotFoundException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleGeneralException(Exception ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/example/memo/memo/service/models/Memo.java
+++ b/src/main/java/com/example/memo/memo/service/models/Memo.java
@@ -35,4 +35,9 @@ public class Memo {
     public void updateTags(List<String> tagIds) {
         this.tags = tagIds;
     }
+
+    public void update(String content, List<Double> embedding) {
+        this.content = content;
+        this.embedding = embedding;
+    }
 }

--- a/src/main/java/com/example/memo/memo/service/models/Memo.java
+++ b/src/main/java/com/example/memo/memo/service/models/Memo.java
@@ -5,9 +5,6 @@ import java.util.List;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;

--- a/src/main/java/com/example/memo/memo/service/models/Tag.java
+++ b/src/main/java/com/example/memo/memo/service/models/Tag.java
@@ -5,9 +5,6 @@ import java.util.List;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -42,5 +39,9 @@ public class Tag {
 
     public void addMemoId(String memoId) {
         memos.add(memoId);
+    }
+
+    public void deleteMemoId(String memoId) {
+        memos.remove(memoId);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,5 +11,6 @@ swagger:
 cors:
   allowedOrigins:
     - ${SWAGGER_SERVER_URL}
+    - ${ALLOWED_ORIGINS_PRODUCT}
     - ${ALLOWED_ORIGINS_DEVELOP}
     - ${ALLOWED_ORIGINS_LOCAL:http://localhost:3000}


### PR DESCRIPTION
# 🔥 연관 이슈

- close #NULL-169

# 🚀 작업 내용

1.  swagger prod 경로 추가
2. 메모 삭제 리팩터링
3. 메모 전체조회 리팩터링
4. 메모 수정 리팩터링
5. 메모 찾기 unspecified 일 경우 404  

# 💬 리뷰 중점사항

1. 메모 삭제의 경우
: 일단 메모를 삭제하고, 태그에 메모id를 삭제합니다. 만약 태그에 연관된 메모가 없을 경우 태그를 삭제합니다.

2. 메모 수정의 경우
: 일단 메모 내용만 수정하는 경우를 구현하였습니다. 태그 수정과 태그 재생성은 리팩터링 후 구현하겠습니다.
일단 메모 바뀐 메모 내용으로 ai서버에서 임베딩값을 받고, 메모내용과 임베딩값을 수정합니다.

# 🖼 스크린샷 (선택)
