### PR TITLE
fix: 이메일 빈문자열 검증 추가

### DIFF
--- a/src/main/java/com/example/oatnote/user/dto/CheckEmailRequest.java
+++ b/src/main/java/com/example/oatnote/user/dto/CheckEmailRequest.java
@@ -7,11 +7,13 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record CheckEmailRequest(
     @Schema(description = "이메일 주소", example = "user@example.com", requiredMode = REQUIRED)
     @Email(message = "유효한 이메일 주소를 입력하세요.")
+    @NotBlank(message = "이메일은 비어있을 수 없습니다.")
     String email
 ) {
 

--- a/src/main/java/com/example/oatnote/user/dto/FindPasswordRequest.java
+++ b/src/main/java/com/example/oatnote/user/dto/FindPasswordRequest.java
@@ -15,6 +15,7 @@ import jakarta.validation.constraints.Size;
 public record FindPasswordRequest(
     @Schema(description = "이메일 주소", example = "user@example.com", requiredMode = REQUIRED)
     @Email(message = "유효한 이메일 주소를 입력하세요.")
+    @NotBlank(message = "이메일은 비어있을 수 없습니다.")
     String email,
 
     @Schema(description = "새 비밀번호", example = "password123!", requiredMode = REQUIRED)

--- a/src/main/java/com/example/oatnote/user/dto/LoginUserRequest.java
+++ b/src/main/java/com/example/oatnote/user/dto/LoginUserRequest.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.NotBlank;
 public record LoginUserRequest(
     @Schema(description = "이메일 주소", example = "user@example.com", requiredMode = REQUIRED)
     @Email(message = "유효한 이메일 주소를 입력하세요.")
+    @NotBlank(message = "이메일은 비어있을 수 없습니다.")
     String email,
 
     @Schema(description = "비밀번호", example = "password123!", requiredMode = REQUIRED)

--- a/src/main/java/com/example/oatnote/user/dto/RegisterUserRequest.java
+++ b/src/main/java/com/example/oatnote/user/dto/RegisterUserRequest.java
@@ -18,6 +18,7 @@ import jakarta.validation.constraints.Size;
 public record RegisterUserRequest(
     @Schema(description = "이메일 주소", example = "user@example.com", requiredMode = REQUIRED)
     @Email(message = "유효한 이메일 주소를 입력하세요.")
+    @NotBlank(message = "이메일은 비어있을 수 없습니다.")
     String email,
 
     @Schema(description = "비밀번호", example = "password123!", requiredMode = REQUIRED)

--- a/src/main/java/com/example/oatnote/user/dto/SendCodeRequest.java
+++ b/src/main/java/com/example/oatnote/user/dto/SendCodeRequest.java
@@ -4,10 +4,12 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 
 public record SendCodeRequest(
     @Schema(description = "이메일 주소", example = "user@example.com", requiredMode = REQUIRED)
     @Email(message = "유효한 이메일 주소를 입력하세요.")
+    @NotBlank(message = "이메일은 비어있을 수 없습니다.")
     String email
 ) {
 

--- a/src/main/java/com/example/oatnote/user/dto/VerifyCodeRequest.java
+++ b/src/main/java/com/example/oatnote/user/dto/VerifyCodeRequest.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.Size;
 public record VerifyCodeRequest(
     @Schema(description = "이메일 주소", example = "user@example.com", requiredMode = REQUIRED)
     @Email(message = "유효한 이메일 주소를 입력하세요.")
+    @NotBlank(message = "이메일은 비어있을 수 없습니다.")
     String email,
 
     @Schema(description = "인증 코드", example = "123456", requiredMode = REQUIRED)


### PR DESCRIPTION
# 🚀 작업 내용

1.  `@Email`로는 빈문자열이 검증이 되지 않아서 `@NotBlank`를 추가했습니다.