### PR TITLE
Null 476 update memo metadata

### DIFF
--- a/src/main/java/com/example/oatnote/domain/memotag/MemoTagService.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/MemoTagService.java
@@ -38,6 +38,7 @@ import com.example.oatnote.domain.memotag.dto.innerDto.SearchHistoryResponse;
 import com.example.oatnote.domain.memotag.rabbitmq.MemoTagMessageProducer;
 import com.example.oatnote.domain.memotag.service.client.AIMemoTagClient;
 import com.example.oatnote.domain.memotag.service.client.dto.AICreateEmbeddingResponse;
+import com.example.oatnote.domain.memotag.service.client.dto.AICreateMetadataResponse;
 import com.example.oatnote.domain.memotag.service.client.dto.AICreateStructureRequest;
 import com.example.oatnote.domain.memotag.service.client.dto.AICreateStructureResponse;
 import com.example.oatnote.domain.memotag.service.client.dto.AICreateTagsRequest;
@@ -238,14 +239,17 @@ public class MemoTagService {
     }
 
     public UpdateMemoResponse updateMemo(String memoId, UpdateMemoRequest updateMemoRequest, String userId) {
-        AICreateEmbeddingResponse aiCreateEmbeddingResponse = aiMemoTagClient.createEmbedding(
-            updateMemoRequest.content()
-        );
+        String content = updateMemoRequest.content();
+        List<String> imageUrls = updateMemoRequest.imageUrls();
+        AICreateEmbeddingResponse aiCreateEmbeddingResponse = aiMemoTagClient.createEmbedding(content);
+        AICreateMetadataResponse aiCreateMetadataResponse = aiMemoTagClient.createMetadata(content, imageUrls);
         Memo memo = memoService.getMemo(memoId, userId);
-        memo.update( //todo metadata
+        memo.update(
             updateMemoRequest.content(),
             updateMemoRequest.imageUrls(),
-            aiCreateEmbeddingResponse.embedding()
+            aiCreateEmbeddingResponse.embedding(),
+            aiCreateMetadataResponse.metadata(),
+            aiCreateMetadataResponse.embeddingMetadata()
         );
         Memo updatedMemo = memoService.updateMemo(memo);
         return UpdateMemoResponse.from(updatedMemo, getLinkedTags(memo.getId(), userId));

--- a/src/main/java/com/example/oatnote/domain/memotag/dto/CreateMemoRequest.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/dto/CreateMemoRequest.java
@@ -22,6 +22,7 @@ import jakarta.validation.constraints.Size;
 public record CreateMemoRequest(
     @Schema(description = "내용", example = "내일은 5시 멘토링을 들어야해", requiredMode = REQUIRED)
     @NotNull(message = "내용은 null일 수 없습니다.")
+    @Size(max = 2000, message = "내용은 최대 2000자까지 입력 가능합니다.")
     String content,
 
     @Schema(

--- a/src/main/java/com/example/oatnote/domain/memotag/dto/CreateMemosRequest.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/dto/CreateMemosRequest.java
@@ -15,7 +15,7 @@ public record CreateMemosRequest(
     @Schema(description = "파일 url", example = "https://example.com/kakao.csv")
     @NotBlank(message = "파일 url은 비워둘 수 없습니다.")
     @AllowedFileType({TXT, CSV})
-    String url
+    String fileUrl
 ) {
 
 }

--- a/src/main/java/com/example/oatnote/domain/memotag/dto/UpdateMemoRequest.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/dto/UpdateMemoRequest.java
@@ -17,6 +17,7 @@ import jakarta.validation.constraints.Size;
 public record UpdateMemoRequest(
     @Schema(description = "내용", example = "내일 5시로 멘토링이 변경되었다.", requiredMode = REQUIRED)
     @NotNull(message = "내용은 null일 수 없습니다.")
+    @Size(max = 2000, message = "내용은 최대 2000자까지 입력 가능합니다.")
     String content,
 
     @Schema(

--- a/src/main/java/com/example/oatnote/domain/memotag/dto/UpdateTagRequest.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/dto/UpdateTagRequest.java
@@ -6,11 +6,13 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record UpdateTagRequest(
     @Schema(description = "태그 이름", example = "일정")
     @Pattern(regexp = "^[a-zA-Z0-9가-힣_\\s]*$", message = "영어, 숫자, 한글, 언더바 및 공백만 허용됩니다.")
+    @Size(max = 20, message = "태그 이름은 최대 10자까지 입력 가능합니다.")
     String name
 ) {
 

--- a/src/main/java/com/example/oatnote/domain/memotag/dto/UpdateTagRequest.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/dto/UpdateTagRequest.java
@@ -12,7 +12,7 @@ import jakarta.validation.constraints.Size;
 public record UpdateTagRequest(
     @Schema(description = "태그 이름", example = "일정")
     @Pattern(regexp = "^[a-zA-Z0-9가-힣_\\s]*$", message = "영어, 숫자, 한글, 언더바 및 공백만 허용됩니다.")
-    @Size(max = 20, message = "태그 이름은 최대 10자까지 입력 가능합니다.")
+    @Size(max = 10, message = "태그 이름은 최대 10자까지 입력 가능합니다.")
     String name
 ) {
 

--- a/src/main/java/com/example/oatnote/domain/memotag/service/client/AIMemoTagClient.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/service/client/AIMemoTagClient.java
@@ -1,6 +1,7 @@
 package com.example.oatnote.domain.memotag.service.client;
 
 import java.net.URI;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +11,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import com.example.oatnote.domain.memotag.service.client.dto.AICreateEmbeddingRequest;
 import com.example.oatnote.domain.memotag.service.client.dto.AICreateEmbeddingResponse;
+import com.example.oatnote.domain.memotag.service.client.dto.AICreateMetadataRequest;
+import com.example.oatnote.domain.memotag.service.client.dto.AICreateMetadataResponse;
 import com.example.oatnote.domain.memotag.service.client.dto.AICreateStructureRequest;
 import com.example.oatnote.domain.memotag.service.client.dto.AICreateStructureResponse;
 import com.example.oatnote.domain.memotag.service.client.dto.AICreateTagsRequest;
@@ -75,15 +78,26 @@ public class AIMemoTagClient {
         return aiSearchMemosResponse.getBody();
     }
 
-    public AICreateEmbeddingResponse createEmbedding(String name) {
+    public AICreateEmbeddingResponse createEmbedding(String content) {
         final URI uri = buildUri("/get-embedding");
-        AICreateEmbeddingRequest aiCreateEmbeddingRequest = AICreateEmbeddingRequest.from(name);
+        AICreateEmbeddingRequest aiCreateEmbeddingRequest = AICreateEmbeddingRequest.from(content);
         ResponseEntity<AICreateEmbeddingResponse> aiCreateEmbeddingResponse = restTemplate.postForEntity(
             uri,
             aiCreateEmbeddingRequest,
             AICreateEmbeddingResponse.class
         );
         return aiCreateEmbeddingResponse.getBody();
+    }
+
+    public AICreateMetadataResponse createMetadata(String content, List<String> imageUrls) {
+        final URI uri = buildUri("/get-embedding");
+        AICreateMetadataRequest aiCreateMetadataRequest = AICreateMetadataRequest.from(content, imageUrls);
+        ResponseEntity<AICreateMetadataResponse> aiCreateMetadataResponse = restTemplate.postForEntity(
+            uri,
+            aiCreateMetadataRequest,
+            AICreateMetadataResponse.class
+        );
+        return aiCreateMetadataResponse.getBody();
     }
 
     private URI buildUri(String path) {

--- a/src/main/java/com/example/oatnote/domain/memotag/service/client/dto/AICreateEmbeddingRequest.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/service/client/dto/AICreateEmbeddingRequest.java
@@ -10,7 +10,7 @@ public record AICreateEmbeddingRequest(
     String content
 ) {
 
-    public static AICreateEmbeddingRequest from(String name) {
-        return new AICreateEmbeddingRequest(name);
+    public static AICreateEmbeddingRequest from(String content) {
+        return new AICreateEmbeddingRequest(content);
     }
 }

--- a/src/main/java/com/example/oatnote/domain/memotag/service/client/dto/AICreateMetadataRequest.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/service/client/dto/AICreateMetadataRequest.java
@@ -5,11 +5,13 @@ import java.util.List;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-import jakarta.validation.constraints.NotEmpty;
-
 @JsonNaming(SnakeCaseStrategy.class)
-public record AICreateEmbeddingResponse(
-    List<Double> embedding
+public record AICreateMetadataRequest(
+    String content,
+    List<String> imageUrls
 ) {
 
+    public static AICreateMetadataRequest from(String content, List<String> imageUrls) {
+        return new AICreateMetadataRequest(content, imageUrls);
+    }
 }

--- a/src/main/java/com/example/oatnote/domain/memotag/service/client/dto/AICreateMetadataResponse.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/service/client/dto/AICreateMetadataResponse.java
@@ -5,11 +5,10 @@ import java.util.List;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-import jakarta.validation.constraints.NotEmpty;
-
 @JsonNaming(SnakeCaseStrategy.class)
-public record AICreateEmbeddingResponse(
-    List<Double> embedding
+public record AICreateMetadataResponse(
+    String metadata,
+    List<Double> embeddingMetadata
 ) {
 
 }

--- a/src/main/java/com/example/oatnote/domain/memotag/service/memo/model/Memo.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/service/memo/model/Memo.java
@@ -29,9 +29,9 @@ public class Memo {
     @Field("uId")
     private String userId;
 
-    private String metadata;
-
     private List<Double> embedding;
+
+    private String metadata;
 
     private List<Double> embeddingMetadata;
 
@@ -53,17 +53,21 @@ public class Memo {
     public void update(
         String content,
         List<String> imageUrls,
-        List<Double> embedding
+        List<Double> embedding,
+        String metadata,
+        List<Double> embeddingMetadata
     ) {
         this.content = content;
         this.imageUrls = imageUrls;
+        this.metadata = metadata;
         this.embedding = embedding;
+        this.embeddingMetadata = embeddingMetadata;
         this.updatedAt = LocalDateTime.now();
     }
 
     public Memo process(String metadata, List<Double> embedding, List<Double> embeddingMetadata) {
-        this.metadata = metadata;
         this.embedding = embedding;
+        this.metadata = metadata;
         this.embeddingMetadata = embeddingMetadata;
         return this;
     }

--- a/src/main/java/com/example/oatnote/domain/user/dto/RegisterUserRequest.java
+++ b/src/main/java/com/example/oatnote/domain/user/dto/RegisterUserRequest.java
@@ -23,9 +23,11 @@ public record RegisterUserRequest(
     @NotBlank(message = "비밀번호는 비어 있을 수 없습니다.")
     @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
     @Pattern(
-        regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$",
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
         message = "비밀번호는 8자 이상의 영어, 숫자, 특수기호의 조합이어야 합니다."
     )
+
+
     String password,
 
     @Schema(description = "비밀번호 확인", example = "password123!", requiredMode = REQUIRED)


### PR DESCRIPTION
# 💬 AS-IS (현재 상황)

1. 메모 업데이트시 메타데이터와 메타데이터임베딩이 수정되지 않음
2. 메모 생성, 수정, 태그 수정 에 글자 제한이 없음
3. 비밀번호 특수문자 제한이 fe와 맞지않음


# 🚀 TO-BE (변경 사항)

1. 메모 수정 시 메타데이터도 변경
2. 글자 제한 추가
3. 특수문자 제한 fe와 통일


### 🖼 스크린샷 (선택 사항)

