### PR TITLE
fix: 루트태그의 자식 태그 반환

### DIFF
--- a/src/main/java/com/example/oatnote/domain/memotag/MemoTagService.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/MemoTagService.java
@@ -94,6 +94,7 @@ public class MemoTagService {
     }
 
     public List<TagResponse> getChildTags(String tagId, String userId) {
+        tagId = Objects.requireNonNullElse(tagId, userId);
         List<Tag> childTags = tagService.getChildTags(tagId, userId);
         return childTags.stream()
             .map(TagResponse::fromTag)


### PR DESCRIPTION
# 💬 AS-IS (현재 상황)

1. 루트태그의 자식태그는 반환안해주는 문제 발생


# 🚀 TO-BE (변경 사항)

1. id null로 들어오면 루트태그 반환해주도록 수정


### 🖼 스크린샷 (선택 사항)

