### PR TITLE
fix: jackson라이브러리에서 정의되지 않은 필드를 json을 java 객체로 변환시 오류 수정

### DIFF
--- a/src/main/java/com/example/oatnote/_commons/config/JacksonConfig.java
+++ b/src/main/java/com/example/oatnote/_commons/config/JacksonConfig.java
@@ -12,16 +12,19 @@ public class JacksonConfig {
 
     @Bean
     public ObjectMapper objectMapper() {
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper objectMapper = new ObjectMapper();
 
         // ENUM 처리
-        mapper.configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
-        mapper.configure(DeserializationFeature.READ_ENUMS_USING_TO_STRING, true);
+        objectMapper.configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+        objectMapper.configure(DeserializationFeature.READ_ENUMS_USING_TO_STRING, true);
 
         // LocalDateTime 처리
-        mapper.registerModule(new JavaTimeModule());
-        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
-        return mapper;
+        // 정의되지 않은 필드를 무시
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        return objectMapper;
     }
 }


### PR DESCRIPTION
# 💬 AS-IS (현재 상황)

1. jackson라이브러리에서 정의되지 않은 필드를 json을 java 객체로 변환시 오류 발생


# 🚀 TO-BE (변경 사항)

1. object mapper를 수정함으로써 불필요한 필드 무시하도록 수정


### 🖼 스크린샷 (선택 사항)

