### PR TITLE
feat: 태그 응답시 메타데이터 추가

### DIFF
--- a/src/main/java/com/example/oatnote/domain/memotag/MemoTagService.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/MemoTagService.java
@@ -79,7 +79,7 @@ public class MemoTagService {
         AiCreateTagsRequest aiCreateTagsRequest = createMemoRequest.toAiCreateMemoRequest(userId);
         AiCreateTagsResponse aiCreateTagsResponse = aiMemoTagClient.createTags(aiCreateTagsRequest);
 
-        Memo memo = createMemoRequest.toRawMemo(userId);
+        Memo memo = createMemoRequest.toRawMemo(userId, aiCreateTagsResponse.metadata());
 
         asyncMemoTagService.createStructure(aiCreateTagsResponse, memo, userId);
 

--- a/src/main/java/com/example/oatnote/domain/memotag/MemoTagService.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/MemoTagService.java
@@ -304,7 +304,8 @@ public class MemoTagService {
         memo.update(
             updateMemoTagsRequest.content(),
             updateMemoTagsRequest.imageUrls(),
-            updateMemoTagsRequest.voiceUrls()
+            updateMemoTagsRequest.voiceUrls(),
+            aiCreateTagsResponse.metadata()
         );
 
         asyncMemoTagService.createStructure(aiCreateTagsResponse, memo, userId);

--- a/src/main/java/com/example/oatnote/domain/memotag/dto/CreateMemoRequest.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/dto/CreateMemoRequest.java
@@ -45,12 +45,13 @@ public record CreateMemoRequest(
         );
     }
 
-    public Memo toRawMemo(String userId) {
+    public Memo toRawMemo(String userId, String metadata) {
         return new Memo(
             content,
             imageUrls,
             voiceUrls,
-            userId
+            userId,
+            metadata
         );
     }
 }

--- a/src/main/java/com/example/oatnote/domain/memotag/service/aiClient/dto/AiCreateStructureRequest.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/service/aiClient/dto/AiCreateStructureRequest.java
@@ -29,6 +29,7 @@ public record AiCreateStructureRequest(
         String content,
         List<String> imageUrls,
         List<String> voiceUrls,
+        String metadata,
         LocalDateTime timestamp,
         List<RawTag> tags
     ) {

--- a/src/main/java/com/example/oatnote/domain/memotag/service/aiClient/dto/AiCreateTagsResponse.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/service/aiClient/dto/AiCreateTagsResponse.java
@@ -10,7 +10,8 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record AiCreateTagsResponse(
-    List<RawTag> tags
+    List<RawTag> tags,
+    String metadata
 ) {
 
     public AiCreateStructureRequest toAiCreateStructureRequest(Memo memo, String userId) {
@@ -18,6 +19,7 @@ public record AiCreateTagsResponse(
             memo.getContent(),
             memo.getImageUrls(),
             memo.getVoiceUrls(),
+            memo.getMetadata(),
             LocalDateTime.now(),
             tags
         );

--- a/src/main/java/com/example/oatnote/domain/memotag/service/memo/model/Memo.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/service/memo/model/Memo.java
@@ -113,11 +113,13 @@ public class Memo {
     public void update(
         String content,
         List<String> imageUrls,
-        List<String> voiceUrls
+        List<String> voiceUrls,
+        String metadata
     ) {
         this.content = content;
         this.imageUrls = imageUrls;
         this.voiceUrls = voiceUrls;
+        this.metadata = metadata;
         this.updatedAt = LocalDateTime.now();
     }
 

--- a/src/main/java/com/example/oatnote/domain/memotag/service/memo/model/Memo.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/service/memo/model/Memo.java
@@ -48,13 +48,15 @@ public class Memo {
         String content,
         List<String> imageUrls,
         List<String> voiceUrls,
-        String userId
+        String userId,
+        String metadata
     ) {
         this.id = UUID.randomUUID().toString();
         this.content = content;
         this.imageUrls = imageUrls;
         this.voiceUrls = voiceUrls;
         this.userId = userId;
+        this.metadata = metadata;
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
     }


### PR DESCRIPTION
# 💬 AS-IS (현재 상황)

1. 태그 생성시 메타데이터도 반환이 안되어 느리고, 사용자 관점에서 불편함


# 🚀 TO-BE (변경 사항)

1. 메타데이터를 반환하여, 사용자가 부가설명을 보게하고, ai서버에서의 처리 속도를 향상함 


### 🖼 스크린샷 (선택 사항)

