### PR TITLE
fix: 검색 히스토리 조회 오류 수정

### DIFF
--- a/src/main/java/com/example/oatnote/domain/memotag/service/searchhistory/SearchHistoryRepository.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/service/searchhistory/SearchHistoryRepository.java
@@ -14,7 +14,6 @@ public interface SearchHistoryRepository extends MongoRepository<SearchHistory, 
     @Query(value = "{ '_id': ?0, 'userId': ?1 }", fields = "{ 'query': 1 }")
     Optional<SearchHistory> findQueryByIdAndUserId(String searchHistoryId, String userId);
 
-    @Query("{ 'query': { $regex: ?0, $options: 'i' }, 'userId': ?1 }")
     Page<SearchHistory> findByUserId(Pageable pageable, String userId);
 
     void deleteByUserId(String userId);


### PR DESCRIPTION
# 💬 AS-IS (현재 상황)

1. 히스토리 페이지 조회에서 오류 발생


# 🚀 TO-BE (변경 사항)

1. 기존 query필드를 삭제하였지만, 쿼리문이 수정되지않아서 오류 발생하여 쿼리문 삭제


### 🖼 스크린샷 (선택 사항)

