### PR TITLE
fix: 태그 이름 변경시 제약 추가

### DIFF
--- a/src/main/java/com/example/oatnote/domain/memotag/dto/CreateChildTagRequest.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/dto/CreateChildTagRequest.java
@@ -9,10 +9,12 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record CreateChildTagRequest(
     @Schema(description = "태그 이름", example = "일정", requiredMode = REQUIRED)
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣_\\s]*$", message = "태그 이름은 영어, 숫자, 한글, 언더바 및 공백만 허용됩니다.")
     String name
 ) {
 

--- a/src/main/java/com/example/oatnote/domain/memotag/dto/UpdateTagRequest.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/dto/UpdateTagRequest.java
@@ -11,7 +11,7 @@ import jakarta.validation.constraints.Size;
 @JsonNaming(SnakeCaseStrategy.class)
 public record UpdateTagRequest(
     @Schema(description = "태그 이름", example = "일정")
-    @Pattern(regexp = "^[a-zA-Z0-9가-힣_\\s]*$", message = "영어, 숫자, 한글, 언더바 및 공백만 허용됩니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣_\\s]*$", message = "태그 이름은 영어, 숫자, 한글, 언더바 및 공백만 허용됩니다.")
     @Size(max = 10, message = "태그 이름은 최대 10자까지 입력 가능합니다.")
     String name
 ) {

--- a/src/main/java/com/example/oatnote/domain/memotag/service/MemoTagService.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/service/MemoTagService.java
@@ -245,7 +245,6 @@ public class MemoTagService {
         return SearchHistoriesResponse.from(pagedSearchHistories, criteria);
     }
 
-
     public MemosResponse getMemos(
         String tagId,
         Integer page,


### PR DESCRIPTION
# 💬 AS-IS (현재 상황)

1. 자식 태그 추가시 이름에 특수문자가 들어감


# 🚀 TO-BE (변경 사항)

1. 자식태그 이름 제약조건을 걸어둠


### 🖼 스크린샷 (선택 사항)

