### PR TITLE
fix: 메모 validation 수정

### DIFF
--- a/src/main/java/com/example/oatnote/domain/memotag/dto/CreateChildTagRequest.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/dto/CreateChildTagRequest.java
@@ -9,12 +9,16 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record CreateChildTagRequest(
     @Schema(description = "태그 이름", example = "일정", requiredMode = REQUIRED)
+    @NotEmpty(message = "태그 이름은 비어있을 수 없습니다.")
     @Pattern(regexp = "^[a-zA-Z0-9가-힣_\\s]*$", message = "태그 이름은 영어, 숫자, 한글, 언더바 및 공백만 허용됩니다.")
+    @Size(max = 10, message = "태그 이름은 최대 10자까지 입력 가능합니다.")
     String name
 ) {
 

--- a/src/main/java/com/example/oatnote/domain/memotag/dto/CreateMemoRequest.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/dto/CreateMemoRequest.java
@@ -22,7 +22,7 @@ import jakarta.validation.constraints.Size;
 public record CreateMemoRequest(
     @Schema(description = "내용", example = "내일은 5시 멘토링을 들어야해", requiredMode = REQUIRED)
     @NotNull(message = "내용은 null일 수 없습니다.")
-    @Size(max = 2000, message = "내용은 최대 2000자까지 입력 가능합니다.")
+    @Size(max = 1000, message = "내용은 최대 1000자까지 입력 가능합니다.")
     String content,
 
     @Schema(description = "이미지 URL 리스트", example = "[\"https://example.com/image1.jpg\"]", requiredMode = REQUIRED)

--- a/src/main/java/com/example/oatnote/domain/memotag/dto/UpdateMemoRequest.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/dto/UpdateMemoRequest.java
@@ -8,6 +8,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import java.util.List;
 
 import com.example.oatnote.web.validation.AllowedFileType;
+import com.example.oatnote.web.validation.MemoAtLeastOneRequired;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -15,10 +16,11 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 @JsonNaming(SnakeCaseStrategy.class)
+@MemoAtLeastOneRequired
 public record UpdateMemoRequest(
     @Schema(description = "내용", example = "내일 5시로 멘토링이 변경되었다.", requiredMode = REQUIRED)
     @NotNull(message = "내용은 null일 수 없습니다.")
-    @Size(max = 2000, message = "내용은 최대 2000자까지 입력 가능합니다.")
+    @Size(max = 1000, message = "내용은 최대 1000자까지 입력 가능합니다.")
     String content,
 
     @Schema(

--- a/src/main/java/com/example/oatnote/domain/memotag/dto/UpdateMemoTagsRequest.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/dto/UpdateMemoTagsRequest.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import com.example.oatnote.domain.memotag.service.client.dto.AiCreateTagsRequest;
 import com.example.oatnote.web.validation.AllowedFileType;
+import com.example.oatnote.web.validation.MemoAtLeastOneRequired;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -16,10 +17,11 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 @JsonNaming(SnakeCaseStrategy.class)
+@MemoAtLeastOneRequired
 public record UpdateMemoTagsRequest(
     @Schema(description = "업데이트할 내용", example = "내일 5시로 멘토링이 변경되었다.", requiredMode = REQUIRED)
     @NotNull(message = "내용은 null일 수 없습니다.")
-    @Size(max = 2000, message = "내용은 최대 2000자까지 입력 가능합니다.")
+    @Size(max = 1000, message = "내용은 최대 1000자까지 입력 가능합니다.")
     String content,
 
     @Schema(

--- a/src/main/java/com/example/oatnote/domain/memotag/dto/UpdateTagRequest.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/dto/UpdateTagRequest.java
@@ -5,12 +5,14 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseS
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record UpdateTagRequest(
     @Schema(description = "태그 이름", example = "일정")
+    @NotEmpty(message = "태그 이름은 비어있을 수 없습니다.")
     @Pattern(regexp = "^[a-zA-Z0-9가-힣_\\s]*$", message = "태그 이름은 영어, 숫자, 한글, 언더바 및 공백만 허용됩니다.")
     @Size(max = 10, message = "태그 이름은 최대 10자까지 입력 가능합니다.")
     String name


### PR DESCRIPTION
# 💬 AS-IS (현재 상황)

1. 메모, 태그 추가, 변경시 예외 발생이 안됨(ex 빈 내용, 크기 등)


# 🚀 TO-BE (변경 사항)

1. validation을 수정함


### 🖼 스크린샷 (선택 사항)

