### PR TITLE
fix: 메모 요청 순서대로 시간 수정

### DIFF
--- a/src/main/java/com/example/oatnote/domain/memotag/service/client/dto/AiCreateStructureRequest.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/service/client/dto/AiCreateStructureRequest.java
@@ -16,14 +16,14 @@ public record AiCreateStructureRequest(
     String userId
 ) {
 
-    public static AiCreateStructureRequest from(List<RawTag> rawTags, Memo memo, String userId) {
+    public static AiCreateStructureRequest from(List<RawTag> rawTags, Memo memo, String userId, LocalDateTime time) {
         return new AiCreateStructureRequest(
             List.of(new RawMemo(
                 memo.getContent(),
                 memo.getImageUrls(),
                 memo.getVoiceUrls(),
                 memo.getMetadata(),
-                LocalDateTime.now(),
+                time,
                 rawTags
             )),
             null,

--- a/src/main/java/com/example/oatnote/domain/memotag/service/client/dto/AiCreateTagsRequest.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/service/client/dto/AiCreateTagsRequest.java
@@ -2,6 +2,7 @@ package com.example.oatnote.domain.memotag.service.client.dto;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;

--- a/src/main/java/com/example/oatnote/domain/memotag/service/client/dto/AiCreateTagsResponse.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/service/client/dto/AiCreateTagsResponse.java
@@ -1,10 +1,8 @@
 package com.example.oatnote.domain.memotag.service.client.dto;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import com.example.oatnote.domain.memotag.service.client.dto.innerDto.RawTag;
-import com.example.oatnote.domain.memotag.service.memo.model.Memo;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -14,21 +12,4 @@ public record AiCreateTagsResponse(
     String metadata
 ) {
 
-    public AiCreateStructureRequest toAiCreateStructureRequest(Memo memo, String userId) {
-        AiCreateStructureRequest.RawMemo rawMemo = new AiCreateStructureRequest.RawMemo(
-            memo.getContent(),
-            memo.getImageUrls(),
-            memo.getVoiceUrls(),
-            memo.getMetadata(),
-            LocalDateTime.now(),
-            tags
-        );
-
-        return new AiCreateStructureRequest(
-            List.of(rawMemo),
-            null,
-            null,
-            userId
-        );
-    }
 }

--- a/src/main/java/com/example/oatnote/domain/memotag/service/memo/model/Memo.java
+++ b/src/main/java/com/example/oatnote/domain/memotag/service/memo/model/Memo.java
@@ -2,6 +2,7 @@ package com.example.oatnote.domain.memotag.service.memo.model;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 import org.springframework.data.annotation.Id;
@@ -61,7 +62,7 @@ public class Memo {
         this.updatedAt = LocalDateTime.now();
     }
 
-    private Memo(
+    public Memo(
         String id,
         String content,
         List<String> imageUrls,
@@ -70,10 +71,9 @@ public class Memo {
         String metadata,
         List<Double> embedding,
         List<Double> embeddingMetadata,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        LocalDateTime time
     ) {
-        this.id = id != null ? id : UUID.randomUUID().toString();
+        this.id = Objects.requireNonNullElse(id, UUID.randomUUID().toString());
         this.content = content;
         this.imageUrls = imageUrls;
         this.voiceUrls = voiceUrls;
@@ -81,33 +81,8 @@ public class Memo {
         this.metadata = metadata;
         this.embedding = embedding;
         this.embeddingMetadata = embeddingMetadata;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-    }
-
-    public static Memo of(
-        String memoId,
-        String content,
-        List<String> imageUrls,
-        List<String> voiceUrls,
-        String userId,
-        String metadata,
-        List<Double> embedding,
-        List<Double> embeddingMetadata,
-        LocalDateTime timestamp
-    ) {
-        return new Memo(
-            memoId,
-            content,
-            imageUrls,
-            voiceUrls,
-            userId,
-            metadata,
-            embedding,
-            embeddingMetadata,
-            timestamp,
-            timestamp
-        );
+        this.createdAt = Objects.requireNonNullElse(createdAt, time);
+        this.updatedAt = time;
     }
 
     public void update(


### PR DESCRIPTION
# 💬 AS-IS (현재 상황)

1. 메모 추가시 태그가 생성 완료되는 시간이 달라 순서대로 저장되지 못함


# 🚀 TO-BE (변경 사항)

1. 요청시 시각을 기록하여 그 순서대로 보여지게끔 수정함


### 🖼 스크린샷 (선택 사항)

